### PR TITLE
Use Headless Chrome

### DIFF
--- a/MinervaBot.py
+++ b/MinervaBot.py
@@ -50,3 +50,13 @@ emprestimos.send_keys(Keys.RETURN)
 # Clica em renovar todos
 renovartodos = driver.find_element_by_partial_link_text("Renovar Todos")
 renovartodos.send_keys(Keys.RETURN)
+
+# Imprime na tela o resultado da renovacao
+tabela = driver.find_elements_by_tag_name('table')[-1]
+linhas = tabela.find_elements_by_tag_name('tr')
+cabecalho = linhas[0].find_elements_by_tag_name('th')
+for livro in linhas[1:]:
+  corpo = livro.find_elements_by_tag_name('td')
+  for x in range(len(corpo)):
+    print(cabecalho[x].get_attribute('innerText'), end=': ')
+    print(corpo[x].get_attribute('innerText').strip())

--- a/MinervaBot.py
+++ b/MinervaBot.py
@@ -5,6 +5,7 @@ Escrito por Vinicius Figueiredo pela primeira vez em 06/2016, usando uma ideia d
 
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.chrome.options import Options
 
 
 # Pega os valores do arquivo de texto de login
@@ -16,8 +17,12 @@ inputlist = read.split('\n')
 inputcpf = inputlist[0]
 inputpassword = inputlist[1]
 
+# Coloca o Chrome em modo headless
+options = Options()
+options.add_argument('--headless')
+
 # Abre o driver e entra na minerva
-driver = webdriver.Chrome()
+driver = webdriver.Chrome(chrome_options=options)
 driver.get('http://minerva.ufrj.br')
 
 # Acha a secao de login e a acessa

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Caso tenha preferência por usar a versão executável, que não requer nem o Py
 ## Requerimentos
 * Python 3.5
 * Selenium (Testado com a versão mais recente: 3.4.1)
-* ChromeDriver 2.29
+* ChromeDriver 2.32
 
 ## Uso
 


### PR DESCRIPTION
Using Chrome in headless mode so it won't open a new window when the script is ran.

Since everything is happening "behind the curtains", now it prints the final result to the standard output – it can be used to automatically create a cron job for the day the book must be renewed, for example.