### PR TITLE
Use an explicit wait for the modal dialog

### DIFF
--- a/MinervaBot.py
+++ b/MinervaBot.py
@@ -1,6 +1,10 @@
 from selenium import webdriver
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 
 # Pega os valores do arquivo de texto de login
@@ -33,10 +37,16 @@ idcpf.send_keys(inputcpf)
 password.send_keys(inputpassword, Keys.RETURN)
 
 # Acha o botao de fechar o popup e o fecha
-driver.implicitly_wait(10)  # Aguarda o modal dialog estar disponivel
-popup = driver.find_element_by_css_selector(
-    '.modal-footer > button[data-dismiss="modal"]')
-popup.send_keys(Keys.RETURN)
+try:
+    WebDriverWait(driver, 10).until(
+        EC.presence_of_element_located((By.ID, 'myModal'))
+    ) # Aguarda o popup estar disponivel
+except TimeoutException:
+    pass
+else:
+    popup = driver.find_element_by_css_selector(
+        '.modal-footer > button[data-dismiss="modal"]')
+    popup.send_keys(Keys.RETURN)
 
 # Acha a secao emprestimos e o acessa
 emprestimos = driver.find_element_by_css_selector('a[href*="bor-loan"]')

--- a/MinervaBot.py
+++ b/MinervaBot.py
@@ -39,11 +39,11 @@ popup = driver.find_element_by_css_selector(
 popup.send_keys(Keys.RETURN)
 
 # Acha a secao emprestimos e o acessa
-emprestimos = driver.find_element_by_css_selector("a[href*='bor-loan']")
+emprestimos = driver.find_element_by_css_selector('a[href*="bor-loan"]')
 emprestimos.send_keys(Keys.RETURN)
 
 # Clica em renovar todos
-renovartodos = driver.find_element_by_partial_link_text("Renovar Todos")
+renovartodos = driver.find_element_by_partial_link_text('Renovar Todos')
 renovartodos.send_keys(Keys.RETURN)
 
 # Imprime na tela o resultado da renovacao


### PR DESCRIPTION
When using an implicit wait we need to wait a predefined amount of time (10 seconds) to close the popup. Instead, we can use an explicit wait to detect the presence of the element and save more than 9 seconds.